### PR TITLE
Detect and recover projectors that are ahead of the event store.

### DIFF
--- a/Samples/ExampleHost/App.config
+++ b/Samples/ExampleHost/App.config
@@ -15,7 +15,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Web.Http.Owin" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -24,6 +24,10 @@
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Owin.Hosting" publicKeyToken="31bf3856ad364e35" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-3.0.1.0" newVersion="3.0.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Samples/ExampleHost/CountsProjector.cs
+++ b/Samples/ExampleHost/CountsProjector.cs
@@ -23,7 +23,7 @@ namespace LiquidProjections.ExampleHost
 
         public void Start()
         {
-            dispatcher.Subscribe(null, async transactions =>
+            dispatcher.Subscribe(null, async (transactions, info) =>
             {
                 await documentCountProjector.Handle(transactions);
             });

--- a/Samples/ExampleHost/ExampleHost.csproj
+++ b/Samples/ExampleHost/ExampleHost.csproj
@@ -39,25 +39,20 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Owin, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.3.0.1\lib\net45\Microsoft.Owin.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.3.1.0\lib\net45\Microsoft.Owin.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Diagnostics, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Diagnostics.3.0.1\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Diagnostics, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Diagnostics.3.1.0\lib\net45\Microsoft.Owin.Diagnostics.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.0.1\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Host.HttpListener, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Host.HttpListener.3.1.0\lib\net45\Microsoft.Owin.Host.HttpListener.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Owin.Hosting, Version=3.0.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.0.1\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Microsoft.Owin.Hosting, Version=3.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Owin.Hosting.3.1.0\lib\net45\Microsoft.Owin.Hosting.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.6.0.4\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.10.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="Owin, Version=1.0.0.0, Culture=neutral, PublicKeyToken=f0ebd12fd5e55cc5, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Owin.1.0\lib\net40\Owin.dll</HintPath>

--- a/Samples/ExampleHost/JsonFileEventStore.cs
+++ b/Samples/ExampleHost/JsonFileEventStore.cs
@@ -72,7 +72,7 @@ namespace LiquidProjections.ExampleHost
                             Body = JsonConvert.DeserializeObject(json, new JsonSerializerSettings
                             {
                                 TypeNameHandling = TypeNameHandling.All,
-                                TypeNameAssemblyFormat = FormatterAssemblyStyle.Full
+                                TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full
                             })
                         });
                     }

--- a/Samples/ExampleHost/packages.config
+++ b/Samples/ExampleHost/packages.config
@@ -4,12 +4,12 @@
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.3" targetFramework="net452" />
-  <package id="Microsoft.Owin" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Diagnostics" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Host.HttpListener" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.Hosting" version="3.0.1" targetFramework="net452" />
-  <package id="Microsoft.Owin.SelfHost" version="3.0.1" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="6.0.4" targetFramework="net45" />
+  <package id="Microsoft.Owin" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Diagnostics" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Host.HttpListener" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.Hosting" version="3.1.0" targetFramework="net45" />
+  <package id="Microsoft.Owin.SelfHost" version="3.1.0" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.2" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net452" />
   <package id="TinyIoC" version="1.3" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Src/LiquidProjections.Abstractions/CreateSubscription.cs
+++ b/Src/LiquidProjections.Abstractions/CreateSubscription.cs
@@ -7,13 +7,40 @@ namespace LiquidProjections.Abstractions
     /// <summary>
     /// Creates a subscription on an event store, starting at the transaction following 
     /// <paramref name="lastProcessedCheckpoint"/>, identified by <paramref name="subscriptionId"/>, and which 
-    /// passed transactions to the provided <paramref name="handler"/>.
+    /// passes any transactions to the provided <paramref name="subscriber"/>.
     /// </summary>
-    /// <param name="lastProcessedCheckpoint"></param>
-    /// <param name="handler"></param>
-    /// <param name="subscriptionId"></param>
-    /// <returns></returns>
+    /// <param name="lastProcessedCheckpoint"> 
+    /// The checkpoint of the transaction the subscriber has last seen, or <c>null</c> to start from the beginning.
+    /// </param>
+    /// <param name="subscriber">
+    /// An object wrapping the various handlers that the subscription will use.
+    /// </param>
+    /// <param name="subscriptionId">
+    /// Identifies this subscription and helps distinct multiple subscriptions. 
+    /// </param>
+    /// <returns>
+    /// A disposable object that will cancel the subscription.
+    /// </returns>
     public delegate IDisposable CreateSubscription(long? lastProcessedCheckpoint,
-        Func<IReadOnlyList<Transaction>, Task> handler,
-        string subscriptionId);
+        Subscriber subscriber, string subscriptionId);
+
+    public class Subscriber
+    {
+        /// <summary>
+        /// Represents a handler that will receive the transactions that the event store pushes to the subscriber.
+        /// </summary>
+        public Func<IReadOnlyList<Transaction>, SubscriptionInfo, Task> HandleTransactions { get; set; }
+
+        /// <summary>
+        /// Represents a handler that the event store will use if the requested checkpoint does not exist. 
+        /// </summary>
+        public Func<SubscriptionInfo, Task> NoSuchCheckpoint { get; set; }
+    }
+
+    public class SubscriptionInfo
+    {
+        public string Id { get; set; }
+
+        public IDisposable Subscription { get; set; }
+    }
 }

--- a/Src/LiquidProjections.Abstractions/LiquidProjections.Abstractions.v3.ncrunchproject
+++ b/Src/LiquidProjections.Abstractions/LiquidProjections.Abstractions.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Src/LiquidProjections.Testing/LiquidProjections.Testing.v3.ncrunchproject
+++ b/Src/LiquidProjections.Testing/LiquidProjections.Testing.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Src/LiquidProjections/Dispatcher.cs
+++ b/Src/LiquidProjections/Dispatcher.cs
@@ -10,62 +10,87 @@ namespace LiquidProjections
     {
         private readonly CreateSubscription createSubscription;
 
-        [Obsolete("The IEventStore interface has been replaced by the SubscribeToEvents delegate")]
-        public Dispatcher(IEventStore eventStore)
-        {
-            if (eventStore == null)
-            {
-                throw new ArgumentNullException(nameof(eventStore));
-            }
-
-            this.createSubscription = eventStore.Subscribe;
-        }
-
         public Dispatcher(CreateSubscription createSubscription)
         {
             this.createSubscription = createSubscription;
         }
 
-        public IDisposable Subscribe(long? checkpoint, Func<IReadOnlyList<Transaction>, Task> handler, string subscriptionId)
+        public IDisposable Subscribe(long? lastProcessedCheckpoint,
+            Func<IReadOnlyList<Transaction>, SubscriptionInfo, Task> handler,
+            SubscriptionOptions options = null)
         {
+            if (options == null)
+            {
+                options = new SubscriptionOptions();
+            }
+
             if (handler == null)
             {
                 throw new ArgumentNullException(nameof(handler));
             }
 
-            var subscriptionMonitor = new object();
-            IDisposable subscription = null;
-
-            lock (subscriptionMonitor)
+            return createSubscription(lastProcessedCheckpoint, new Subscriber
             {
-                subscription = createSubscription(checkpoint,
-                    async transactions =>
-                    {
-                        try
-                        {
-                            await handler(transactions);
-                        }
-                        catch (Exception exception)
-                        {
-                            LogProvider.GetLogger(typeof(Dispatcher)).FatalException(
-                                "Projector exception was not handled. Event subscription has been cancelled.",
-                                exception);
-
-                            lock (subscriptionMonitor)
-                            {
-                                subscription.Dispose();
-                            }
-                        }
-                    },
-                    subscriptionId);
-            }
-
-            return subscription;
+                HandleTransactions = async (transactions, info) => await HandleTransactions(transactions, handler, info),
+                NoSuchCheckpoint = async info => await HandleUnknownCheckpoint(info, handler, options)
+            }, options.Id);
         }
 
-        public IDisposable Subscribe(long? checkpoint, Func<IReadOnlyList<Transaction>, Task> handler)
+        private static async Task HandleTransactions(IReadOnlyList<Transaction> transactions, Func<IReadOnlyList<Transaction>, SubscriptionInfo, Task> handler, SubscriptionInfo info)
         {
-            return Subscribe(checkpoint, handler, null);
+            try
+            {
+                await handler(transactions, info);
+            }
+            catch (Exception exception)
+            {
+                LogProvider.GetLogger(typeof(Dispatcher)).FatalException(
+                    "Projector exception was not handled. Event subscription has been cancelled.",
+                    exception);
+
+                info.Subscription?.Dispose();
+            }
         }
+
+        private async Task HandleUnknownCheckpoint(SubscriptionInfo info, Func<IReadOnlyList<Transaction>, SubscriptionInfo, Task> handler, SubscriptionOptions options)
+        {
+            if (options.RestartWhenAhead)
+            {
+                try
+                {
+                    info.Subscription?.Dispose();
+
+                    await options.BeforeRestarting();
+
+                    Subscribe(null, handler, options);
+                }
+                catch (Exception exception)
+                {
+                    LogProvider.GetLogger(typeof(Dispatcher)).FatalException(
+                        "Failed to restart the projector.",
+                        exception);
+                }
+            }
+        }
+    }
+
+    public class SubscriptionOptions
+    {
+        /// <summary>
+        /// Can be used by subscribers to understand which is which.
+        /// </summary>
+        public string Id { get; set; }
+
+        /// <summary>
+        /// If set to <c>true</c>, the dispatcher will automatically restart at the first transaction if it detects
+        /// that the subscriber is ahead of the event store (e.g. because it got restored to an earlier time).
+        /// </summary>
+        public bool RestartWhenAhead { get; set; }
+
+        /// <summary>
+        /// If restarting is enabled through <see cref="RestartWhenAhead"/>, this property can be used to run some
+        /// clean-up code before the dispatcher will restart at the first transaction.
+        /// </summary>
+        public Func<Task> BeforeRestarting { get; set; } = () => Task.FromResult(0);
     }
 }

--- a/Src/LiquidProjections/EnumerableExtensions.cs
+++ b/Src/LiquidProjections/EnumerableExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+
+namespace LiquidProjections
+{
+    [DebuggerNonUserCode]
+    internal static class EnumerableExtensions
+    {
+        public static IReadOnlyList<T> ToReadOnly<T>(this IEnumerable<T> items)
+        {
+            return new ReadOnlyCollection<T>(items.ToList());
+        }
+    }
+}

--- a/Src/LiquidProjections/LiquidProjections.v3.ncrunchproject
+++ b/Src/LiquidProjections/LiquidProjections.v3.ncrunchproject
@@ -1,0 +1,5 @@
+﻿<ProjectConfiguration>
+  <Settings>
+    <PreviouslyBuiltSuccessfully>True</PreviouslyBuiltSuccessfully>
+  </Settings>
+</ProjectConfiguration>

--- a/Tests/LiquidProjections.Specs/LiquidProjections.Specs.csproj
+++ b/Tests/LiquidProjections.Specs/LiquidProjections.Specs.csproj
@@ -34,17 +34,14 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Chill, Version=2.4.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Chill.2.4.1\Lib\net45\Chill.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Chill, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Chill.3.0.0\lib\net45\Chill.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=4.18.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\FluentAssertions.4.18.0\lib\net45\FluentAssertions.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="FluentAssertions.Core, Version=4.19.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\FluentAssertions.4.19.2\lib\net45\FluentAssertions.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -55,20 +52,16 @@
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.assert.2.1.0\lib\dotnet\xunit.assert.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.core, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.core.2.1.0\lib\dotnet\xunit.core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.execution.desktop, Version=2.1.0.3179, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\xunit.extensibility.execution.2.1.0\lib\net45\xunit.execution.desktop.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -77,9 +70,8 @@
     <Compile Include="ProjectionExceptionSpecs.cs" />
     <Compile Include="ProjectorSpecs.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Compile Include="TaskExtensions.cs" />
+    <Compile Include="TransactionBuilder.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Src\LiquidProjections.Abstractions\LiquidProjections.Abstractions.csproj">
@@ -97,6 +89,9 @@
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/Tests/LiquidProjections.Specs/ProjectorSpecs.cs
+++ b/Tests/LiquidProjections.Specs/ProjectorSpecs.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Chill;
 using FluentAssertions;
+using LiquidProjections.Abstractions;
+using LiquidProjections.Testing;
 using Xunit;
 
 namespace LiquidProjections.Specs
@@ -27,7 +29,10 @@ namespace LiquidProjections.Specs
 
             protected void StartProjecting()
             {
-                The<MemoryEventSource>().Subscribe(110, Subject.Handle, "");
+                The<MemoryEventSource>().Subscribe(110, new Subscriber
+                {
+                    HandleTransactions = async (transactions, info) => await Subject.Handle(transactions)
+                }, "");
             }
         }
 
@@ -115,7 +120,7 @@ namespace LiquidProjections.Specs
                 When(async () =>
                 {
                     await The<MemoryEventSource>().Write(new ProductAddedToCatalogEvent());
-                }, deferedExecution: true);
+                }, deferredExecution: true);
             }
 
             [Fact]
@@ -230,7 +235,7 @@ namespace LiquidProjections.Specs
                     StartProjecting();
                 });
 
-                When(() => The<MemoryEventSource>().Write(The<Transaction>()), deferedExecution: true);
+                When(() => The<MemoryEventSource>().Write(The<Transaction>()), deferredExecution: true);
             }
 
             [Fact]

--- a/Tests/LiquidProjections.Specs/TaskExtensions.cs
+++ b/Tests/LiquidProjections.Specs/TaskExtensions.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LiquidProjections.Specs
+{
+    internal static class TaskExtensions
+    {
+        public static async Task<TResult> TimeoutAfter<TResult>(this Task<TResult> task, TimeSpan timeout)
+        {
+            var timeoutCancellationTokenSource = new CancellationTokenSource();
+
+            var completedTask = await Task.WhenAny(task, Task.Delay(timeout, timeoutCancellationTokenSource.Token));
+            if (completedTask == task)
+            {
+                timeoutCancellationTokenSource.Cancel();
+                return await task;  // Very important in order to propagate exceptions
+            }
+            else
+            {
+                throw new TimeoutException("The operation has timed out.");
+            }
+        }
+    }
+}

--- a/Tests/LiquidProjections.Specs/TransactionBuilder.cs
+++ b/Tests/LiquidProjections.Specs/TransactionBuilder.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace LiquidProjections.Specs
+{
+    internal class TransactionBuilder
+    {
+        private long checkpoint;
+
+        public TransactionBuilder WithCheckpoint(long checkpoint)
+        {
+            this.checkpoint = checkpoint;
+            return this;
+        }
+
+        public Transaction Build()
+        {
+            return new Transaction
+            {
+                Checkpoint = checkpoint,
+                Id = Guid.NewGuid().ToString(),
+                StreamId = Guid.NewGuid().ToString(),
+                TimeStampUtc = DateTime.UtcNow
+            };
+        }
+    }
+}

--- a/Tests/LiquidProjections.Specs/packages.config
+++ b/Tests/LiquidProjections.Specs/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Chill" version="2.4.1" targetFramework="net452" />
-  <package id="FluentAssertions" version="4.18.0" targetFramework="net452" />
-  <package id="xunit" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.abstractions" version="2.0.0" targetFramework="net452" />
-  <package id="xunit.assert" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net452" />
-  <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net452" />
+  <package id="Chill" version="3.0.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="4.19.2" targetFramework="net452" />
+  <package id="xunit" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net452" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net452" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Adds a new options object that allows a subscriber to tell the dispatcher to restart the subscription at the first transaction available in the underlying event source, and allow the subscriber to clean-up just before that.