### PR TITLE
Allowed the OWIN API to work with any implementation of IProjectorStats

### DIFF
--- a/Src/LiquidProjections.Owin/CustomNancyBootstrapper.cs
+++ b/Src/LiquidProjections.Owin/CustomNancyBootstrapper.cs
@@ -20,9 +20,9 @@ namespace LiquidProjections.Owin
 {
     internal class CustomNancyBootstrapper : DefaultNancyBootstrapper
     {
-        private readonly ProjectionStats stats;
+        private readonly IProjectionStats stats;
 
-        public CustomNancyBootstrapper(ProjectionStats stats)
+        public CustomNancyBootstrapper(IProjectionStats stats)
         {
             this.stats = stats;
         }

--- a/Src/LiquidProjections.Owin/MiddlewareExtensions.cs
+++ b/Src/LiquidProjections.Owin/MiddlewareExtensions.cs
@@ -6,7 +6,7 @@ namespace LiquidProjections.Owin
 {
     public static class MiddlewareExtensions
     {
-        public static IAppBuilder UseLiquidProjections(this IAppBuilder appBuilder, ProjectionStats stats)
+        public static IAppBuilder UseLiquidProjections(this IAppBuilder appBuilder, IProjectionStats stats)
         {
             appBuilder.Map("/projectionStats", a => a.UseNancy(new NancyOptions
             {

--- a/Src/LiquidProjections/LiquidProjections.csproj
+++ b/Src/LiquidProjections/LiquidProjections.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFramework>netstandard1.1</TargetFramework>
     <PackageId />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DefineConstants>TRACE;DEBUG;NETSTANDARD1_1;LIBLOG_PORTABLE</DefineConstants>
     <DocumentationFile>bin\Debug\netstandard1.1\LiquidProjections.xml</DocumentationFile>
@@ -13,7 +11,6 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
-
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <DefineConstants>TRACE;RELEASE;LIBLOG_PORTABLE;NETSTANDARD1_1</DefineConstants>
     <DocumentationFile>bin\Release\netstandard1.1\LiquidProjections.xml</DocumentationFile>
@@ -21,15 +18,12 @@
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
     <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="LibLog" Version="4.2.6" />
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\LiquidProjections.Abstractions\LiquidProjections.Abstractions.csproj" />
   </ItemGroup>
-
 </Project>

--- a/Src/LiquidProjections/Statistics/IProjectionStats.cs
+++ b/Src/LiquidProjections/Statistics/IProjectionStats.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace LiquidProjections.Statistics
+{
+    public interface IProjectionStats : IEnumerable<IProjectorStats>
+    {
+        /// <summary>
+        /// Should be called to track the progress of a projector and use that to calculate an ETA.
+        /// </summary>
+        void TrackProgress(string projectorId, long checkpoint);
+
+        /// <summary>
+        /// Can be used to store projector-specific properties that characterize the projector's configuration or state. 
+        /// </summary>
+        /// <remarks>
+        /// Each property is identified by a <paramref name="name"/>. This class only keeps the latest value
+        /// for each property.
+        /// </remarks>
+        void StoreProperty(string projectorId, string name, string value);
+
+        /// <summary>
+        /// Can be used to store information that happened that can help diagnose the state or failure of a projector.
+        /// </summary>
+        void LogEvent(string projectorId, string body);
+
+        /// <summary>
+        /// Gets the speed in transactions per minute based on a weighted average over the last
+        /// ten minutes, or <c>null</c> if there is not enough information yet.        
+        /// </summary>
+        /// <param name="projectorId"></param>
+        float? GetSpeed(string projectorId);
+
+        /// <summary>
+        /// Calculates the expected time for the projector identified by <paramref name="projectorId"/> to reach a 
+        /// certain <paramref name="targetCheckpoint"/> based on a weighted average over the last 
+        /// ten minutes, or <c>null</c> if there is not enough information yet. Use <see cref="ProjectionStats.TrackProgress"/> to report
+        /// progress.
+        /// </summary>
+        TimeSpan? GetTimeToReach(string projectorId, long targetCheckpoint);
+
+        /// <summary>
+        /// Gets the stats for an individual projector.
+        /// </summary>
+        IProjectorStats Get(string projectorId);
+    }
+}

--- a/Src/LiquidProjections/Statistics/ProjectionStats.cs
+++ b/Src/LiquidProjections/Statistics/ProjectionStats.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
@@ -8,7 +9,7 @@ namespace LiquidProjections.Statistics
     /// <summary>
     /// Provides a thread-safe place to store all kinds of run-time information about the progress of a projector. 
     /// </summary>
-    public class ProjectionStats
+    public class ProjectionStats : IProjectionStats
     {
         private readonly Func<DateTime> nowUtc;
         private readonly ConcurrentDictionary<string, ProjectorStats> stats = new ConcurrentDictionary<string, ProjectorStats>();
@@ -67,10 +68,16 @@ namespace LiquidProjections.Statistics
             return this[projectorId].GetTimeToReach(targetCheckpoint);
         }
 
+        /// <inheritdoc />
+        public IProjectorStats Get(string projectorId)
+        {
+            return this[projectorId];
+        }
+
         /// <summary>
         /// Gets the statistics for a particular projector.
         /// </summary>
-        public ProjectorStats this[string projectorId]
+        private ProjectorStats this[string projectorId]
         {
             get
             {
@@ -78,9 +85,14 @@ namespace LiquidProjections.Statistics
             }
         }
 
-        public IEnumerable<ProjectorStats> GetForAllProjectors()
+        public IEnumerator<IProjectorStats> GetEnumerator()
         {
-            return stats.ToArray().Select(projectorStatsById => projectorStatsById.Value);
+            return stats.Values.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
         }
     }
 }

--- a/Src/LiquidProjections/Statistics/ProjectorStats.cs
+++ b/Src/LiquidProjections/Statistics/ProjectorStats.cs
@@ -5,13 +5,29 @@ using System.Linq;
 
 namespace LiquidProjections.Statistics
 {
+    public interface IProjectorStats
+    {
+        string ProjectorId { get; }
+        TimestampedCheckpoint LastCheckpoint { get; }
+
+        /// <summary>
+        /// Gets a snapshot of the properties stored for this projector at the time of calling.
+        /// </summary>
+        IDictionary<string, Property> GetProperties();
+
+        /// <summary>
+        /// Gets a snapshot of the events stored for this projector at the time of calling.
+        /// </summary>
+        IReadOnlyList<Event> GetEvents();
+    }
+
     /// <summary>
     /// Contains statistics and information about a particular projector.
     /// </summary>
     /// <remarks>
     /// An instance of this class is safe for use in multi-threaded solutions.
     /// </remarks>
-    public class ProjectorStats
+    public class ProjectorStats : IProjectorStats
     {
         private readonly object eventsSyncObject = new object();
         private readonly object progressSyncObject = new object();

--- a/Tests/LiquidProjections.Specs/ProjectionStatsSpecs.cs
+++ b/Tests/LiquidProjections.Specs/ProjectionStatsSpecs.cs
@@ -29,7 +29,7 @@ namespace LiquidProjections.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            var projectorStats = stats.GetForAllProjectors().Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
+            var projectorStats = stats.Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
             projectorStats.LastCheckpoint.Checkpoint.Should().Be(2000);
             projectorStats.LastCheckpoint.TimestampUtc.Should().Be(nowUtc);
         }
@@ -53,7 +53,7 @@ namespace LiquidProjections.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            var projectorStats = stats.GetForAllProjectors().Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
+            var projectorStats = stats.Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
 
             projectorStats.GetProperties().Should().ContainKey("theName");
             projectorStats.GetProperties()["theName"].Should().BeEquivalentTo(new
@@ -83,7 +83,7 @@ namespace LiquidProjections.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            var projectorStats = stats.GetForAllProjectors().Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
+            var projectorStats = stats.Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
 
             projectorStats.GetProperties().Should().ContainKey("aName");
             projectorStats.GetProperties()["aName"].Should().BeEquivalentTo(new
@@ -121,7 +121,7 @@ namespace LiquidProjections.Specs
             //-----------------------------------------------------------------------------------------------------------
             // Assert
             //-----------------------------------------------------------------------------------------------------------
-            var projectorStats = stats.GetForAllProjectors().Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
+            var projectorStats = stats.Should().ContainSingle(s => s.ProjectorId == "myProjector").Subject;
             projectorStats.GetEvents().Should().BeEquivalentTo(new[]
             {
                 new


### PR DESCRIPTION
By extracting an interface from `ProjectionState` and use that in `UseLiquidProjections`, it is possible to use the OWIN endpoint without directly coupling it to the `ProjectionStats`. For example, an application may want to expose cached or persisted statistics extracted from a projector, rather than getting the live data.