### PR TITLE
LiquidProjections.Abstractions version requirement updated to 3.0 - 4.0 range

### DIFF
--- a/Src/LiquidProjections.Testing/.nuspec
+++ b/Src/LiquidProjections.Testing/.nuspec
@@ -13,7 +13,7 @@
         <releaseNotes/>
       <dependencies>
         <group>
-			<dependency id="LiquidProjections.Abstractions" version="$nugetversion$"/>
+			<dependency id="LiquidProjections.Abstractions" version="[3.0, 4.0)"/>
 		</group>
       </dependencies>
     </metadata>

--- a/Src/LiquidProjections/.nuspec
+++ b/Src/LiquidProjections/.nuspec
@@ -13,7 +13,7 @@
         <releaseNotes/>
       <dependencies>
         <group>
-          <dependency id="LiquidProjections.Abstractions" version="$nugetversion$"/>
+          <dependency id="LiquidProjections.Abstractions" version="[3.0, 4.0)"/>
     		</group>
       </dependencies>
     </metadata>


### PR DESCRIPTION
So there is no need to release new Abstractions package every time the main LP package updated.